### PR TITLE
JCodec 0.1.4 is not available in Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ You can get JCodec automatically with maven. For this just add below snippet to 
 <dependency>
     <groupId>org.jcodec</groupId>
     <artifactId>jcodec</artifactId>
-    <version>0.1.4</version>
+    <version>0.1.3</version>
 </dependency>
 ```
+
 OR download it from here:
 * [JCodec 0.1.4 JAR](http://jcodec.org/downloads/jcodec-0.1.4.jar), [GPG Sign](http://jcodec.org/downloads/jcodec-0.1.4.jar.asc), [POM](http://jcodec.org/downloads/jcodec-0.1.4.pom)
 


### PR DESCRIPTION
Hi,

At the very beginning I would like to thank you for this marvelous project :) Keep it up!

I wanted to download JCodec from Maven Central, but it seems like it's not available there (check [here](http://search.maven.org/#search|gav|1|g%3A%22org.jcodec%22%20AND%20a%3A%22jcodec%22) for complete list of JCodec releases).

Therefor I bumped POM dependency version one number down to make it compatible with the Maven Central artifacts, otherwise people will get an error when try to use it via POM dependency.