### PR TITLE
ArrayIndexOutOfBoundsException while using gotoFrame() method

### DIFF
--- a/src/main/java/org/jcodec/containers/mp4/demuxer/FramesMP4DemuxerTrack.java
+++ b/src/main/java/org/jcodec/containers/mp4/demuxer/FramesMP4DemuxerTrack.java
@@ -148,9 +148,16 @@ public class FramesMP4DemuxerTrack extends AbstractMP4DemuxerTrack {
             offInChunk += sizes[(int) frameNo - noInChunk + i];
         }
 
-        if (syncSamples != null)
-            for (ssOff = 0; syncSamples[ssOff] < curFrame + 1; ssOff++)
-                ;
+        if (syncSamples != null){
+			ssOff = 0;
+			for(int i = 0; i < syncSamples.length; i++){
+				if(syncSamples[i] < curFrame + 1){
+					ssOff++;
+				} else {
+					break;
+				}
+			}
+		}
 
     }
 


### PR DESCRIPTION
Fix issue with gotoFrame method. If frameNo is greater than index of last IDR sample (sync sample) in video track, method throws ArrayIndexOutOfBoundsException.
Proposed code guarantees that syncSamples array is never going to be read out of bounds.
