### PR TITLE
Added SPS constraint flags 4 & 5 for Constrained & Progressive High Profile

### DIFF
--- a/src/main/java/org/jcodec/codecs/h264/io/model/SeqParameterSet.java
+++ b/src/main/java/org/jcodec/codecs/h264/io/model/SeqParameterSet.java
@@ -50,6 +50,8 @@ public class SeqParameterSet {
     public boolean constraint_set_1_flag;
     public boolean constraint_set_2_flag;
     public boolean constraint_set_3_flag;
+    public boolean constraint_set_4_flag;
+    public boolean constraint_set_5_flag;
     public int level_idc;
     public int seq_parameter_set_id;
     public boolean residual_color_transform_flag;
@@ -105,7 +107,9 @@ public class SeqParameterSet {
         sps.constraint_set_1_flag = readBool(in, "SPS: constraint_set_1_flag");
         sps.constraint_set_2_flag = readBool(in, "SPS: constraint_set_2_flag");
         sps.constraint_set_3_flag = readBool(in, "SPS: constraint_set_3_flag");
-        readNBit(in, 4, "SPS: reserved_zero_4bits");
+        sps.constraint_set_4_flag = readBool(in, "SPS: constraint_set_4_flag");
+        sps.constraint_set_5_flag = readBool(in, "SPS: constraint_set_5_flag");
+        readNBit(in, 2, "SPS: reserved_zero_2bits");
         sps.level_idc = (int) readNBit(in, 8, "SPS: level_idc");
         sps.seq_parameter_set_id = readUE(in, "SPS: seq_parameter_set_id");
 
@@ -269,7 +273,9 @@ public class SeqParameterSet {
         writeBool(writer, constraint_set_1_flag, "SPS: constraint_set_1_flag");
         writeBool(writer, constraint_set_2_flag, "SPS: constraint_set_2_flag");
         writeBool(writer, constraint_set_3_flag, "SPS: constraint_set_3_flag");
-        writeNBit(writer, 0, 4, "SPS: reserved");
+        writeBool(writer, constraint_set_4_flag, "SPS: constraint_set_4_flag");
+        writeBool(writer, constraint_set_5_flag, "SPS: constraint_set_5_flag");
+        writeNBit(writer, 0, 2, "SPS: reserved");
         writeNBit(writer, level_idc, 8, "SPS: level_idc");
         writeUE(writer, seq_parameter_set_id, "SPS: seq_parameter_set_id");
 
@@ -490,6 +496,14 @@ public class SeqParameterSet {
 
     public boolean isConstraint_set_3_flag() {
         return constraint_set_3_flag;
+    }
+    
+    public boolean isConstraint_set_4_flag() {
+        return constraint_set_4_flag;
+    }
+    
+    public boolean isConstraint_set_5_flag() {
+        return constraint_set_5_flag;
     }
 
     public int getLevel_idc() {

--- a/src/test/java/org/jcodec/codecs/h264/SPSReadTest.java
+++ b/src/test/java/org/jcodec/codecs/h264/SPSReadTest.java
@@ -26,6 +26,8 @@ public class SPSReadTest extends TestCase {
         sps1.constraint_set_1_flag = false;
         sps1.constraint_set_2_flag = false;
         sps1.constraint_set_3_flag = false;
+        sps1.constraint_set_4_flag = false;
+        sps1.constraint_set_5_flag = false;
         sps1.level_idc = 30;
         sps1.seq_parameter_set_id = 0;
         sps1.log2_max_frame_num_minus4 = 5;
@@ -79,6 +81,8 @@ public class SPSReadTest extends TestCase {
             assertEquals(sps.constraint_set_1_flag, false);
             assertEquals(sps.constraint_set_2_flag, false);
             assertEquals(sps.constraint_set_3_flag, false);
+            assertEquals(sps.constraint_set_4_flag, false);
+            assertEquals(sps.constraint_set_5_flag, false);
             assertEquals(sps.level_idc, 30);
             assertEquals(sps.seq_parameter_set_id, 0);
             assertEquals(sps.log2_max_frame_num_minus4, 5);


### PR DESCRIPTION
This PR adds the required constraint flags for Progressive High Profile and Constrained High Profile. These were added in H.264 specifications released in 2011-06 and 2012-01 respectively. This change ensures that these flags are propagated from SeqParameterSet.read() to SeqParameterSet.write(), rather than being discarded as they are now.

I'm using your library to parse incoming SPS NALUs to do some hardware-specific fixups in my project. As of now, I haven't needed to mess with these constraint flags, but a change in Intel's hardware decoding code in Android 6.0 requires that I set these constraint flags to indicate that the hardware should enter low delay mode (since there are guaranteed to be no B-frames).

With this change, I'll be able to use Jcodec to write the modified SPS containing the new constraint flags. In addition, constraint flag 4 is already being set by the incoming stream, however it is dropped when I rewrite the SPS after passing it through the SeqParameterSet object. With this change, the flag will properly remain set.

FFmpeg's similar change: http://ffmpeg.org/pipermail/ffmpeg-cvslog/2012-July/052172.html

Code using Jcodec in my project: https://github.com/moonlight-stream/moonlight-android/blob/master/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java#L470
Change in Intel's Android decoder (if you're curious): https://android.googlesource.com/platform/hardware/intel/common/libmix/+/9892b9c8b325cc6fc1e3fb98455b3701e89c8885%5E%21/videodecoder/VideoDecoderAVC.cpp