### PR TITLE
Add ColorSpace option to H264Encoder

### DIFF
--- a/src/main/java/org/jcodec/codecs/h264/H264Encoder.java
+++ b/src/main/java/org/jcodec/codecs/h264/H264Encoder.java
@@ -56,6 +56,7 @@ public class H264Encoder extends VideoEncoder {
     private RateControl rc;
     private int frameNumber;
     private int keyInterval;
+    private ColorSpace colorSpace = ColorSpace.YUV420J;
 
     private int maxPOC;
 
@@ -87,7 +88,21 @@ public class H264Encoder extends VideoEncoder {
     public void setKeyInterval(int keyInterval) {
         this.keyInterval = keyInterval;
     }
-    
+
+    public ColorSpace getColorSpace() {
+        return this.colorSpace;
+    }
+
+    public void setColorSpace(ColorSpace colorSpace) {
+        for (ColorSpace cs : getSupportedColorSpaces()) {
+            if (cs == colorSpace) {
+                this.colorSpace = colorSpace;
+                return;
+            }
+        }
+        throw new IllegalArgumentException("ColorSpace " + colorSpace + " is not supported.");
+    }
+
     /**
      * Encode this picture into h.264 frame. Frame type will be selected by
      * encoder.
@@ -159,10 +174,10 @@ public class H264Encoder extends VideoEncoder {
         topLine = new byte[][] { new byte[mbWidth << 4], new byte[mbWidth << 3], new byte[mbWidth << 3] };
         picOut = Picture8Bit.create(mbWidth << 4, mbHeight << 4, pic.getColor());
 
-        outMB = new EncodedMB();
+        outMB = new EncodedMB(this.colorSpace);
         topEncoded = new EncodedMB[mbWidth];
         for (int i = 0; i < mbWidth; i++)
-            topEncoded[i] = new EncodedMB();
+            topEncoded[i] = new EncodedMB(this.colorSpace);
 
         encodeSlice(sps, pps, pic, dup, idr, frameNumber, frameType);
 
@@ -198,7 +213,7 @@ public class H264Encoder extends VideoEncoder {
         SeqParameterSet sps = new SeqParameterSet();
         sps.pic_width_in_mbs_minus1 = ((sz.getWidth() + 15) >> 4) - 1;
         sps.pic_height_in_map_units_minus1 = ((sz.getHeight() + 15) >> 4) - 1;
-        sps.chroma_format_idc = ColorSpace.YUV420J;
+        sps.chroma_format_idc = this.colorSpace;
         sps.profile_idc = 66;
         sps.level_idc = 40;
         sps.frame_mbs_only_flag = true;
@@ -344,7 +359,7 @@ public class H264Encoder extends VideoEncoder {
 
     @Override
     public ColorSpace[] getSupportedColorSpaces() {
-        return new ColorSpace[] { ColorSpace.YUV420J };
+        return new ColorSpace[] { ColorSpace.YUV420J, ColorSpace.YUV420 };
     }
 
     @Override

--- a/src/main/java/org/jcodec/codecs/h264/encode/EncodedMB.java
+++ b/src/main/java/org/jcodec/codecs/h264/encode/EncodedMB.java
@@ -19,7 +19,11 @@ public class EncodedMB {
     private int[] my;
 
     public EncodedMB() {
-        pixels = Picture8Bit.create(16, 16, ColorSpace.YUV420J);
+        this(ColorSpace.YUV420J);
+    }
+
+    public EncodedMB(ColorSpace colorSpace) {
+        pixels = Picture8Bit.create(16, 16, colorSpace);
         nc = new int[16];
         mx = new int[16];
         my = new int[16];

--- a/src/main/java/org/jcodec/codecs/h264/io/CAVLC.java
+++ b/src/main/java/org/jcodec/codecs/h264/io/CAVLC.java
@@ -188,6 +188,8 @@ public class CAVLC {
     protected VLC codeTableChromaDC() {
         if (color == ColorSpace.YUV420J) {
             return H264Const.coeffTokenChromaDCY420;
+        } else if (color == ColorSpace.YUV420) {
+            return H264Const.coeffTokenChromaDCY420;
         } else if (color == YUV422) {
             return H264Const.coeffTokenChromaDCY422;
         } else if (color == YUV444) {

--- a/src/test/java/org/jcodec/codecs/h264/H264EncoderTest.java
+++ b/src/test/java/org/jcodec/codecs/h264/H264EncoderTest.java
@@ -1,0 +1,40 @@
+package org.jcodec.codecs.h264;
+
+import org.jcodec.codecs.h264.encode.DumbRateControl;
+import org.jcodec.common.model.ColorSpace;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This class is part of JCodec ( www.jcodec.org ) This software is distributed
+ * under FreeBSD License
+ *
+ * @author The JCodec project
+ *
+ */
+public class H264EncoderTest {
+
+    @Test
+    public void testGetColorSpace_Default() throws Exception {
+        H264Encoder encoder = new H264Encoder(new DumbRateControl());
+        Assert.assertEquals("H264Encoder should default to color space YUV420J.", ColorSpace.YUV420J, encoder.getColorSpace());
+    }
+
+    @Test
+    public void testSetColorSpace() throws Exception {
+        H264Encoder encoder = new H264Encoder(new DumbRateControl());
+        encoder.setColorSpace(ColorSpace.YUV420);
+        Assert.assertEquals("H264Encoder did not change to the requested color space.", ColorSpace.YUV420, encoder.getColorSpace());
+        // and set it back to the default
+        encoder.setColorSpace(ColorSpace.YUV420J);
+        Assert.assertEquals("H264Encoder did not change to the requested color space.", ColorSpace.YUV420J, encoder.getColorSpace());
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetColorSpace_Unsupported() throws Exception {
+        H264Encoder encoder = new H264Encoder(new DumbRateControl());
+        encoder.setColorSpace(ColorSpace.BGR);
+    }
+
+}


### PR DESCRIPTION
Enables H264Encoder so encode either in YUV420J (the default) or YUV420.