### PR TITLE
fixed bug in NIOUtils.readl() - last buffer was skipped

### DIFF
--- a/src/main/java/org/jcodec/common/io/NIOUtils.java
+++ b/src/main/java/org/jcodec/common/io/NIOUtils.java
@@ -146,14 +146,10 @@ public class NIOUtils {
     public static int readL(ReadableByteChannel channel, ByteBuffer buffer, int length) throws IOException {
         ByteBuffer fork = buffer.duplicate();
         fork.limit(min(fork.position() + length, fork.limit()));
-        int read;
-        while ((read = channel.read(fork)) != -1 && fork.hasRemaining())
+        while (channel.read(fork) != -1 && fork.hasRemaining())
             ;
-        if (read == -1)
-            return -1;
-
         buffer.position(fork.position());
-        return read;
+        return buffer.position() == 0 ? -1 : buffer.position();
     }
 
     public static int readFromChannel(ReadableByteChannel channel, ByteBuffer buffer) throws IOException {


### PR DESCRIPTION
The problem was, that when the last portion was read, then channel.read(fork) will place bytes into fork but also return -1. Then readl() also returns -1 without updating the buffer.position(). So the last portion is not delivered. Also if the while() loop is executed multiple times then only the amount of the last read() was returned. 