### PR TITLE
[mp4] MP4 container doesn't know the color space

### DIFF
--- a/src/main/java/org/jcodec/api/transcode/SourceImpl.java
+++ b/src/main/java/org/jcodec/api/transcode/SourceImpl.java
@@ -400,9 +400,11 @@ public class SourceImpl implements Source, PacketSource {
 
     @Override
     public VideoCodecMeta getVideoCodecMeta() {
+        if (videoCodecMeta != null)
+            return videoCodecMeta;
         DemuxerTrackMeta meta = getTrackVideoMeta();
         if (meta != null && meta.getVideoCodecMeta() != null) {
-            return meta.getVideoCodecMeta();
+            videoCodecMeta = meta.getVideoCodecMeta();
         }
         return videoCodecMeta;
     }

--- a/src/main/java/org/jcodec/containers/mp4/demuxer/MP4DemuxerTrackMeta.java
+++ b/src/main/java/org/jcodec/containers/mp4/demuxer/MP4DemuxerTrackMeta.java
@@ -53,7 +53,7 @@ public class MP4DemuxerTrackMeta {
         VideoCodecMeta videoCodecMeta = null;
         AudioCodecMeta audioCodecMeta = null;
         if (type == MP4TrackType.VIDEO) {
-            videoCodecMeta = createSimpleVideoCodecMeta(trak.getCodedSize(), ColorSpace.YUV420);
+            videoCodecMeta = createSimpleVideoCodecMeta(trak.getCodedSize(), null);
             PixelAspectExt pasp = NodeBox.findFirst(track.getSampleEntries()[0], PixelAspectExt.class, "pasp");
             if (pasp != null)
                 videoCodecMeta.setPixelAspectRatio(pasp.getRational());

--- a/src/main/java/org/jcodec/containers/mp4/demuxer/MP4DemuxerTrackMeta.java
+++ b/src/main/java/org/jcodec/containers/mp4/demuxer/MP4DemuxerTrackMeta.java
@@ -6,9 +6,11 @@ import static org.jcodec.common.TrackType.VIDEO;
 import static org.jcodec.common.VideoCodecMeta.createSimpleVideoCodecMeta;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 
 import org.jcodec.codecs.aac.AACUtils;
 import org.jcodec.codecs.h264.H264Utils;
+import org.jcodec.codecs.h264.io.model.SeqParameterSet;
 import org.jcodec.codecs.h264.mp4.AvcCBox;
 import org.jcodec.common.AudioCodecMeta;
 import org.jcodec.common.Codec;
@@ -53,7 +55,7 @@ public class MP4DemuxerTrackMeta {
         VideoCodecMeta videoCodecMeta = null;
         AudioCodecMeta audioCodecMeta = null;
         if (type == MP4TrackType.VIDEO) {
-            videoCodecMeta = createSimpleVideoCodecMeta(trak.getCodedSize(), null);
+            videoCodecMeta = createSimpleVideoCodecMeta(trak.getCodedSize(), getColorInfo(track));
             PixelAspectExt pasp = NodeBox.findFirst(track.getSampleEntries()[0], PixelAspectExt.class, "pasp");
             if (pasp != null)
                 videoCodecMeta.setPixelAspectRatio(pasp.getRational());
@@ -84,6 +86,19 @@ public class MP4DemuxerTrackMeta {
         }
 
         return meta;
+    }
+
+    protected static ColorSpace getColorInfo(AbstractMP4DemuxerTrack track) {
+        Codec codec = Codec.codecByFourcc(track.getFourcc());
+        if (codec == Codec.H264) {
+            AvcCBox avcC = H264Utils.parseAVCC((VideoSampleEntry) track.getSampleEntries()[0]);
+            List<ByteBuffer> spsList = avcC.getSpsList();
+            if (spsList.size() > 0) {
+                SeqParameterSet sps = SeqParameterSet.read(spsList.get(0));
+                return sps.getChromaFormatIdc();
+            }
+        }
+        return null;
     }
 
     public static ByteBuffer getCodecPrivate(AbstractMP4DemuxerTrack track) {

--- a/src/test/java/org/jcodec/containers/mp4/demuxer/MP4DemuxerTest.java
+++ b/src/test/java/org/jcodec/containers/mp4/demuxer/MP4DemuxerTest.java
@@ -2,7 +2,10 @@ package org.jcodec.containers.mp4.demuxer;
 
 import org.jcodec.common.AutoFileChannelWrapper;
 import org.jcodec.common.DemuxerTrack;
+import org.jcodec.common.DemuxerTrackMeta;
+import org.jcodec.common.io.NIOUtils;
 import org.jcodec.common.io.SeekableByteChannel;
+import org.jcodec.common.model.ColorSpace;
 import org.jcodec.common.model.Packet;
 import org.jcodec.platform.Platform;
 import org.junit.Test;
@@ -13,6 +16,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.ByteBuffer;
+
+import junit.framework.Assert;
 
 public class MP4DemuxerTest {
     
@@ -38,6 +43,9 @@ public class MP4DemuxerTest {
         File source = new File(resource.getFile());
         SeekableByteChannel input = new AutoFileChannelWrapper(source);
         MP4Demuxer demuxer = MP4Demuxer.createMP4Demuxer(input);
+//        DemuxerTrack videoTrack = demuxer.getVideoTrack();
+//        DemuxerTrackMeta meta = videoTrack.getMeta();
+//        assertEquals(ColorSpace.YUV420, meta.getVideoCodecMeta().getColor());
         DemuxerTrack track = demuxer.getAudioTracks().get(0);
         Packet packet;
         while (null != (packet = track.nextFrame())) {
@@ -55,5 +63,20 @@ public class MP4DemuxerTest {
         MP4Demuxer demuxer = MP4Demuxer.createMP4Demuxer(input);
         PCMMP4DemuxerTrack track = (PCMMP4DemuxerTrack) demuxer.getAudioTracks().get(0);
         assertEquals(6, track.getFrameSize());
+    }
+    
+    @Test
+    public void testVideoColor() throws Exception {
+        File source = new File("src/test/resources/AVCClipCatTest/cat_avc_clip.mp4");
+        SeekableByteChannel input = null;
+        try {
+            input = NIOUtils.readableChannel(source);
+            MP4Demuxer demuxer = MP4Demuxer.createMP4Demuxer(input);
+            DemuxerTrack videoTrack = demuxer.getVideoTrack();
+            DemuxerTrackMeta meta = videoTrack.getMeta();
+            assertEquals(ColorSpace.YUV420J, meta.getVideoCodecMeta().getColor());
+        } finally {
+            NIOUtils.closeQuietly(input);
+        }
     }
 }

--- a/src/test/java/org/jcodec/containers/mp4/demuxer/MP4DemuxerTest.java
+++ b/src/test/java/org/jcodec/containers/mp4/demuxer/MP4DemuxerTest.java
@@ -43,9 +43,6 @@ public class MP4DemuxerTest {
         File source = new File(resource.getFile());
         SeekableByteChannel input = new AutoFileChannelWrapper(source);
         MP4Demuxer demuxer = MP4Demuxer.createMP4Demuxer(input);
-//        DemuxerTrack videoTrack = demuxer.getVideoTrack();
-//        DemuxerTrackMeta meta = videoTrack.getMeta();
-//        assertEquals(ColorSpace.YUV420, meta.getVideoCodecMeta().getColor());
         DemuxerTrack track = demuxer.getAudioTracks().get(0);
         Packet packet;
         while (null != (packet = track.nextFrame())) {


### PR DESCRIPTION
So it reports a dummy value of YUV420p which is incorrect for ProRes. Setting null (because we don't know) and figuring out from the actual coded picture.