### PR TITLE
[color] Fixing RGB/BGR ambiguity in AWTUTil

### DIFF
--- a/javase/src/main/java/org/jcodec/codecs/pngawt/PNGEncoder.java
+++ b/javase/src/main/java/org/jcodec/codecs/pngawt/PNGEncoder.java
@@ -1,5 +1,8 @@
 package org.jcodec.codecs.pngawt;
 
+import static org.jcodec.common.model.ColorSpace.BGR;
+import static org.jcodec.common.model.ColorSpace.RGB;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -31,7 +34,10 @@ public class PNGEncoder extends VideoEncoder {
         if (rgbToBgr == null) {
             rgbToBgr = new RgbToBgr();
         }
-        rgbToBgr.transform(pic, pic);
+        if (pic.getColor() == RGB)
+            rgbToBgr.transform(pic, pic);
+        else if (pic.getColor() != BGR)
+            throw new IllegalArgumentException("Unsupported input color space: " + pic.getColor());
 
         AWTUtil.toBufferedImage(pic, bi);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/javase/src/main/java/org/jcodec/scale/AWTUtil.java
+++ b/javase/src/main/java/org/jcodec/scale/AWTUtil.java
@@ -21,7 +21,9 @@ import static org.jcodec.common.model.ColorSpace.RGB;
  */
 public class AWTUtil {
     public static BufferedImage toBufferedImage(Picture src) {
-        if (src.getColor() != ColorSpace.RGB) {
+        if (src.getColor() == ColorSpace.RGB) {
+            new RgbToBgr().transform(src, src);
+        } else if (src.getColor() != ColorSpace.BGR) {
             Transform transform = ColorUtil.getTransform(src.getColor(), ColorSpace.RGB);
             Picture rgb = Picture.createCropped(src.getWidth(), src.getHeight(), ColorSpace.RGB, src.getCrop());
             transform.transform(src, rgb);
@@ -41,7 +43,9 @@ public class AWTUtil {
     }
 
     public static BufferedImage toBufferedImage(Picture src, DemuxerTrackMeta.Orientation orientation) {
-        if (src.getColor() != ColorSpace.RGB) {
+        if (src.getColor() == ColorSpace.RGB) {
+            new RgbToBgr().transform(src, src);
+        } else if (src.getColor() != ColorSpace.BGR) {
             Transform transform = ColorUtil.getTransform(src.getColor(), ColorSpace.RGB);
             Picture rgb = Picture.createCropped(src.getWidth(), src.getHeight(), ColorSpace.RGB, src.getCrop());
             transform.transform(src, rgb);

--- a/src/test/java/org/jcodec/scale/AWTUtil.java
+++ b/src/test/java/org/jcodec/scale/AWTUtil.java
@@ -23,7 +23,9 @@ public class AWTUtil {
     }
 
     public static BufferedImage toBufferedImage(Picture src) {
-        if (src.getColor() != ColorSpace.RGB) {
+        if (src.getColor() == ColorSpace.RGB) {
+            new RgbToBgr().transform(src, src);
+        } else if (src.getColor() != ColorSpace.BGR) {
             Transform transform = ColorUtil.getTransform(src.getColor(), ColorSpace.RGB);
             if (transform == null) {
                 throw new IllegalArgumentException("Unsupported input colorspace: " + src.getColor());


### PR DESCRIPTION
In AWTUtil the BufferedImage is created with color space BGR however the entire color transform is skipped if the input color is RGB. Introducing the correct behavior of RGB->BGR when the input is RGB, no op if the input is BGR and generic color transform otherwise.