### PR TITLE
[mp4] Corect moov size estimation

### DIFF
--- a/src/main/java/org/jcodec/codecs/h264/mp4/AvcCBox.java
+++ b/src/main/java/org/jcodec/codecs/h264/mp4/AvcCBox.java
@@ -87,7 +87,6 @@ public class AvcCBox extends Box {
 
     @Override
     public void doWrite(ByteBuffer out) {
-
         out.put((byte) 0x1); // version
         out.put((byte) profile);
         out.put((byte) profileCompat);
@@ -107,6 +106,19 @@ public class AvcCBox extends Box {
             out.put((byte) 0x68);
             NIOUtils.write(out, pps);
         }
+    }
+    
+    @Override
+    public int estimateSize() {
+        int sz = 17;
+        for (ByteBuffer sps : spsList) {
+            sz += 3 + sps.remaining();
+        }
+
+        for (ByteBuffer pps : ppsList) {
+            sz += 3 + pps.remaining();
+        }
+        return sz;
     }
 
     public int getProfile() {

--- a/src/main/java/org/jcodec/codecs/mpeg4/mp4/EsdsBox.java
+++ b/src/main/java/org/jcodec/codecs/mpeg4/mp4/EsdsBox.java
@@ -60,6 +60,11 @@ public class EsdsBox extends FullBox {
             new ES(trackId, l).write(out);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 64;
+    }
 
     public void parse(ByteBuffer input) {
         super.parse(input);

--- a/src/main/java/org/jcodec/containers/mp4/boxes/AliasBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/AliasBox.java
@@ -154,6 +154,17 @@ public class AliasBox extends FullBox {
         out.putShort((short) -1);
         out.putShort((short) 0);
     }
+    
+    @Override
+    public int estimateSize() {
+        int sz = 166;
+        if ((flags & 0x1) == 0) {
+            for (ExtraField extraField : extra) {
+                sz += 4 + extraField.data.length;
+            }
+        }
+        return 12 + sz;
+    }
 
     public int getRecordSize() {
         return recordSize;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/Box.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/Box.java
@@ -1,19 +1,16 @@
 package org.jcodec.containers.mp4.boxes;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jcodec.common.Assert;
 import org.jcodec.common.StringUtils;
 import org.jcodec.common.UsedViaReflection;
 import org.jcodec.common.io.NIOUtils;
-import org.jcodec.common.logging.Logger;
 import org.jcodec.common.tools.ToJSON;
 import org.jcodec.containers.mp4.IBoxFactory;
 import org.jcodec.platform.Platform;
-
-import java.lang.StringBuilder;
-import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This class is part of JCodec ( www.jcodec.org ) This software is distributed
@@ -50,6 +47,8 @@ public abstract class Box {
     }
 
     protected abstract void doWrite(ByteBuffer out);
+    
+    public abstract int estimateSize();
 
     public String getFourcc() {
         return header.getFourcc();
@@ -125,6 +124,11 @@ public abstract class Box {
         @Override
         protected void doWrite(ByteBuffer out) {
             NIOUtils.write(out, data);
+        }
+
+        @Override
+        public int estimateSize() {
+            return data.remaining() + Header.estimateHeaderSize(data.remaining());
         }
     }
     

--- a/src/main/java/org/jcodec/containers/mp4/boxes/ChannelBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/ChannelBox.java
@@ -88,6 +88,11 @@ public class ChannelBox extends FullBox {
             out.putFloat(channelDescription.getCoordinates()[2]);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 12 + 12 + descriptions.length * 20;
+    }
 
     public int getChannelLayout() {
         return channelLayout;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/ChunkOffsets64Box.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/ChunkOffsets64Box.java
@@ -46,6 +46,11 @@ public class ChunkOffsets64Box extends FullBox {
         }
     }
     
+    @Override
+    public int estimateSize() {
+        return 12 + 4 + chunkOffsets.length * 8;
+    }
+    
     public long[] getChunkOffsets() {
         return chunkOffsets;
     }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/ChunkOffsetsBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/ChunkOffsetsBox.java
@@ -48,6 +48,11 @@ public class ChunkOffsetsBox extends FullBox {
             out.putInt((int) offset);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 12 + 4 + chunkOffsets.length * 4;
+    }
 
     public long[] getChunkOffsets() {
         return chunkOffsets;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/CleanApertureExtension.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/CleanApertureExtension.java
@@ -70,4 +70,9 @@ public class CleanApertureExtension extends Box {
         out.putInt((int) this.vertOffsetNumerator);
         out.putInt((int) this.vertOffsetDenominator);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 32 + 8;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/ClearApertureBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/ClearApertureBox.java
@@ -36,6 +36,11 @@ public class ClearApertureBox extends FullBox {
         out.putInt((int) (width * 65536f));
         out.putInt((int) (height * 65536f));
     }
+    
+    @Override
+    public int estimateSize() {
+        return 20;
+    }
 
     public float getWidth() {
         return width;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/ClipRegionBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/ClipRegionBox.java
@@ -50,6 +50,11 @@ public class ClipRegionBox extends Box {
         out.putShort(height);
         out.putShort(width);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 10 + 8;
+    }
 
     public short getRgnSize() {
         return rgnSize;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/ColorExtension.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/ColorExtension.java
@@ -57,6 +57,11 @@ public class ColorExtension extends Box {
             out.put(colorRange);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 8 + 8;
+    }
 
     public static String fourcc() {
         return "colr";

--- a/src/main/java/org/jcodec/containers/mp4/boxes/CompositionOffsetsBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/CompositionOffsetsBox.java
@@ -86,6 +86,11 @@ public class CompositionOffsetsBox extends FullBox {
             out.putInt(entries[i].offset);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 12 + 4 + entries.length * 8;
+    }
 
     public Entry[] getEntries() {
         return entries;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/DataRefBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/DataRefBox.java
@@ -36,4 +36,9 @@ public class DataRefBox extends NodeBox {
         out.putInt(boxes.size());
         super.doWrite(out);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 8 + super.estimateSize();
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/EditListBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/EditListBox.java
@@ -51,6 +51,11 @@ public class EditListBox extends FullBox {
             out.putInt((int) (edit.getRate() * 65536));
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 12 + 4 + edits.size() * 12;
+    }
 
     public List<Edit> getEdits() {
         return edits;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/EndianBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/EndianBox.java
@@ -40,6 +40,11 @@ public class EndianBox extends Box {
     protected void doWrite(ByteBuffer out) {
         out.putShort((short) (endian == ByteOrder.LITTLE_ENDIAN ? 1 : 0));
     }
+    
+    @Override
+    public int estimateSize() {
+        return 2 + 8;
+    }
 
     public ByteOrder getEndian() {
         return endian;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/FielExtension.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/FielExtension.java
@@ -66,4 +66,9 @@ public class FielExtension extends Box {
         out.put((byte) type);
         out.put((byte) order);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 2 + 8;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/FileTypeBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/FileTypeBox.java
@@ -65,4 +65,15 @@ public class FileTypeBox extends Box {
             out.put(JCodecUtil2.asciiString(string));
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        int size = 5 + 8;
+
+        for (String string : compBrands) {
+            size += JCodecUtil2.asciiString(string).length;
+        }
+
+        return size;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/FormatBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/FormatBox.java
@@ -37,4 +37,9 @@ public class FormatBox extends Box {
     protected void doWrite(ByteBuffer out) {
         out.put(asciiString(fmt));
     }
+    
+    @Override
+    public int estimateSize() {
+        return asciiString(fmt).length + 8;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/FullBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/FullBox.java
@@ -1,5 +1,7 @@
 package org.jcodec.containers.mp4.boxes;
 
+import static org.jcodec.common.JCodecUtil2.asciiString;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -9,7 +11,7 @@ import java.nio.ByteBuffer;
  * @author The JCodec project
  * 
  */
-public class FullBox extends Box {
+public abstract class FullBox extends Box {
 
     public FullBox(Header atom) {
         super(atom);
@@ -27,7 +29,7 @@ public class FullBox extends Box {
     protected void doWrite(ByteBuffer out) {
         out.putInt((version << 24) | (flags & 0xffffff));
     }
-
+    
     public byte getVersion() {
         return version;
     }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/GamaExtension.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/GamaExtension.java
@@ -41,4 +41,8 @@ public class GamaExtension extends Box {
         return "gama";
     }
 
+    @Override
+    public int estimateSize() {
+        return 12;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/GenericMediaInfoBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/GenericMediaInfoBox.java
@@ -47,4 +47,9 @@ public class GenericMediaInfoBox extends FullBox {
         out.putShort(balance);
         out.putShort((short) 0);
     }
+
+    @Override
+    public int estimateSize() {
+        return 24;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/HandlerBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/HandlerBox.java
@@ -68,6 +68,12 @@ public class HandlerBox extends FullBox {
             out.put(asciiString(componentName));
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 12 + asciiString(componentType).length + asciiString(componentSubType).length
+                + asciiString(componentManufacturer).length + 9;
+    }
 
     public String getComponentType() {
         return componentType;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/Header.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/Header.java
@@ -76,6 +76,10 @@ public class Header {
     public long headerSize() {
         return lng || (size > MAX_UNSIGNED_INT) ? 16 : 8;
     }
+    
+    public static int estimateHeaderSize(int size) {
+        return size + 8 > MAX_UNSIGNED_INT ? 16 : 8;
+    }
 
     public byte[] readContents(InputStream di) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/src/main/java/org/jcodec/containers/mp4/boxes/LoadSettingsBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/LoadSettingsBox.java
@@ -38,6 +38,11 @@ public class LoadSettingsBox extends Box {
         out.putInt(preloadFlags);
         out.putInt(defaultHints);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 24;
+    }
 
     public int getPreloadStartTime() {
         return preloadStartTime;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/MP4ABox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/MP4ABox.java
@@ -24,4 +24,9 @@ public class MP4ABox extends Box {
     public void parse(ByteBuffer input) {
         val = input.getInt();
     }
+
+    @Override
+    public int estimateSize() {
+        return 12;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/MediaHeaderBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/MediaHeaderBox.java
@@ -100,4 +100,9 @@ public class MediaHeaderBox extends FullBox {
         out.putShort((short) language);
         out.putShort((short) quality);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 32;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/MovieExtendsHeaderBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/MovieExtendsHeaderBox.java
@@ -33,6 +33,11 @@ public class MovieExtendsHeaderBox extends FullBox {
         super.doWrite(out);
         out.putInt(fragmentDuration);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 16;
+    }
 
     public int getFragmentDuration() {
         return fragmentDuration;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/MovieFragmentHeaderBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/MovieFragmentHeaderBox.java
@@ -35,6 +35,11 @@ public class MovieFragmentHeaderBox extends FullBox {
         super.doWrite(out);
         out.putInt(sequenceNumber);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 16;
+    }
 
     public int getSequenceNumber() {
         return sequenceNumber;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/MovieHeaderBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/MovieHeaderBox.java
@@ -143,6 +143,11 @@ public class MovieHeaderBox extends FullBox {
         out.put(new byte[24]);
         out.putInt(nextTrackId);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 144;
+    }
 
     private void writeMatrix(ByteBuffer out) {
         for (int i = 0; i < Math.min(9, matrix.length); i++)

--- a/src/main/java/org/jcodec/containers/mp4/boxes/NameBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/NameBox.java
@@ -37,6 +37,11 @@ public class NameBox extends Box {
         out.put(JCodecUtil2.asciiString(name));
         out.putInt(0);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 12 + JCodecUtil2.asciiString(name).length;
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/NodeBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/NodeBox.java
@@ -77,6 +77,15 @@ public class NodeBox extends Box {
             box.write(out);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        int total = 0;
+        for (Box box : boxes) {
+            total += box.estimateSize();
+        }
+        return total + Header.estimateHeaderSize(total);
+    }
 
     public void addFirst(MovieHeaderBox box) {
         boxes.add(0, box);

--- a/src/main/java/org/jcodec/containers/mp4/boxes/PixelAspectExt.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/PixelAspectExt.java
@@ -37,6 +37,11 @@ public class PixelAspectExt extends Box {
         out.putInt(hSpacing);
         out.putInt(vSpacing);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 16;
+    }
 
     public int gethSpacing() {
         return hSpacing;
@@ -53,5 +58,4 @@ public class PixelAspectExt extends Box {
     public static String fourcc() {
         return "pasp";
     }
-
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/SampleDescriptionBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/SampleDescriptionBox.java
@@ -41,4 +41,9 @@ public class SampleDescriptionBox extends NodeBox {
         out.putInt(Math.max(1, boxes.size()));
         super.doWrite(out);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 8 + super.estimateSize();
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/SampleEntry.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/SampleEntry.java
@@ -50,4 +50,9 @@ public class SampleEntry extends NodeBox {
     public void setMediaType(String mediaType) {
         header = new Header(mediaType);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 8 + super.estimateSize();
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/SampleSizesBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/SampleSizesBox.java
@@ -80,6 +80,11 @@ public class SampleSizesBox extends FullBox {
             out.putInt((int)count);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return (defaultSize == 0 ? sizes.length * 4 : 0) + 20;
+    }
 
     public void setSizes(int[] sizes) {
         this.sizes = sizes;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/SampleToChunkBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/SampleToChunkBox.java
@@ -91,6 +91,11 @@ public class SampleToChunkBox extends FullBox {
             out.putInt((int) stc.getEntry());
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 16 + sampleToChunk.length * 12;
+    }
 
     public void setSampleToChunk(SampleToChunkEntry[] sampleToChunk) {
         this.sampleToChunk = sampleToChunk;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/SegmentIndexBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/SegmentIndexBox.java
@@ -110,6 +110,11 @@ public class SegmentIndexBox extends FullBox {
             out.putInt(i2);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 40 + reference_count * 12;
+    }
 
     @Override
     public String toString() {
@@ -119,5 +124,4 @@ public class SegmentIndexBox extends FullBox {
                 + Platform.arrayToString(references) + ", version=" + version + ", flags=" + flags + ", header="
                 + header + "]";
     }
-
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/SegmentTypeBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/SegmentTypeBox.java
@@ -65,4 +65,14 @@ public class SegmentTypeBox extends Box {
             out.put(JCodecUtil2.asciiString(string));
         }
     }
+
+    @Override
+    public int estimateSize() {
+        int sz = 13;
+
+        for (String string : compBrands) {
+            sz += JCodecUtil2.asciiString(string).length;
+        }
+        return sz;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/SoundMediaHeaderBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/SoundMediaHeaderBox.java
@@ -37,6 +37,11 @@ public class SoundMediaHeaderBox extends FullBox {
         out.putShort(balance);
         out.putShort((short) 0);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 16;
+    }
 
     public short getBalance() {
         return balance;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/SyncSamplesBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/SyncSamplesBox.java
@@ -41,6 +41,11 @@ public class SyncSamplesBox extends FullBox {
             out.putInt((int) syncSamples[i]);
     }
 
+    @Override
+    public int estimateSize() {
+        return 16 + syncSamples.length * 4;
+    }
+    
     public int[] getSyncSamples() {
         return syncSamples;
     }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/TimeToSampleBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/TimeToSampleBox.java
@@ -82,6 +82,11 @@ public class TimeToSampleBox extends FullBox {
             out.putInt(timeToSampleEntry.getSampleDuration());
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        return 16 + entries.length * 8;
+    }
 
     public void setEntries(TimeToSampleEntry[] entries) {
         this.entries = entries;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/TimecodeMediaInfoBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/TimecodeMediaInfoBox.java
@@ -73,4 +73,9 @@ public class TimecodeMediaInfoBox extends FullBox {
         out.putShort(bgcolor[2]);
         NIOUtils.writePascalString(out, name);
     }
+
+    @Override
+    public int estimateSize() {
+        return 32 + 1 + NIOUtils.asciiString(name).length;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/TrackExtendsBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/TrackExtendsBox.java
@@ -47,6 +47,11 @@ public class TrackExtendsBox extends FullBox {
         out.putInt(defaultSampleBytes);
         out.putInt(defaultSampleFlags);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 32;
+    }
 
     public int getTrackId() {
         return trackId;
@@ -91,5 +96,4 @@ public class TrackExtendsBox extends FullBox {
     public static TrackExtendsBox createTrackExtendsBox() {
         return new TrackExtendsBox(new Header(fourcc()));
     }
-
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/TrackFragmentBaseMediaDecodeTimeBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/TrackFragmentBaseMediaDecodeTimeBox.java
@@ -62,6 +62,11 @@ public class TrackFragmentBaseMediaDecodeTimeBox extends FullBox {
         } else
             throw new RuntimeException("Unsupported tfdt version");
     }
+    
+    @Override
+    public int estimateSize() {
+        return 20;
+    }
 
     public long getBaseMediaDecodeTime() {
         return baseMediaDecodeTime;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/TrackFragmentHeaderBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/TrackFragmentHeaderBox.java
@@ -143,6 +143,11 @@ public class TrackFragmentHeaderBox extends FullBox {
         if (isDefaultSampleFlagsAvailable())
             out.putInt(defaultSampleFlags);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 40;
+    }
 
     public int getTrackId() {
         return trackId;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/TrackHeaderBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/TrackHeaderBox.java
@@ -135,11 +135,15 @@ public class TrackHeaderBox extends FullBox {
         out.putInt((int) (width * 65536));
         out.putInt((int) (height * 65536));
     }
+    
+    @Override
+    public int estimateSize() {
+        return 92;
+    }
 
     private void writeMatrix(ByteBuffer out) {
         for (int i = 0; i < 9; i++)
             out.putInt(matrix[i]);
-
     }
 
     private void writeVolume(ByteBuffer out) {

--- a/src/main/java/org/jcodec/containers/mp4/boxes/TrunBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/TrunBox.java
@@ -306,4 +306,8 @@ public class TrunBox extends FullBox {
         }
     }
 
+    @Override
+    public int estimateSize() {
+        return 24 + sampleCount * 16;
+    }
 }

--- a/src/main/java/org/jcodec/containers/mp4/boxes/UrlBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/UrlBox.java
@@ -52,6 +52,18 @@ public class UrlBox extends FullBox {
             out.put((byte) 0);
         }
     }
+    
+    @Override
+    public int estimateSize() {
+        int sz = 13;
+
+        Charset utf8 = Charset.forName("utf-8");
+
+        if (url != null) {
+            sz += Platform.getBytesForCharset(url, utf8).length;
+        }
+        return sz;
+    }
 
     public String getUrl() {
         return url;

--- a/src/main/java/org/jcodec/containers/mp4/boxes/VideoMediaHeaderBox.java
+++ b/src/main/java/org/jcodec/containers/mp4/boxes/VideoMediaHeaderBox.java
@@ -50,6 +50,11 @@ public class VideoMediaHeaderBox extends FullBox {
         out.putShort((short) gOpColor);
         out.putShort((short) bOpColor);
     }
+    
+    @Override
+    public int estimateSize() {
+        return 20;
+    }
 
     public int getGraphicsMode() {
         return graphicsMode;


### PR DESCRIPTION
Prevents buffer overflow in flattern and movtools by correctly estimating the movie box size.