### PR TITLE
[h264] Fixing bug with num_ref_frames

### DIFF
--- a/src/main/java/org/jcodec/codecs/h264/H264Encoder.java
+++ b/src/main/java/org/jcodec/codecs/h264/H264Encoder.java
@@ -215,6 +215,7 @@ public class H264Encoder extends VideoEncoder {
         sps.chromaFormatIdc = ColorSpace.YUV420J;
         sps.profileIdc = 66;
         sps.levelIdc = 40;
+        sps.numRefFrames = 1;
         sps.frameMbsOnlyFlag = true;
         sps.log2MaxFrameNumMinus4 = Math.max(0, MathUtil.log2(keyInterval) - 3);
 


### PR DESCRIPTION
The number of reference frames was set to 0 (a left over from when
the encoder was I-frame only) which caused some players to not
display P-frames correctly.