### PR TITLE
[h264_enc] Fixing buffer overflow condition on random pixels

### DIFF
--- a/src/main/java/org/jcodec/codecs/h264/encode/DumbRateControl.java
+++ b/src/main/java/org/jcodec/codecs/h264/encode/DumbRateControl.java
@@ -1,6 +1,7 @@
 package org.jcodec.codecs.h264.encode;
 
 import org.jcodec.codecs.h264.io.model.SliceType;
+import org.jcodec.common.model.Size;
 
 /**
  * This class is part of JCodec ( www.jcodec.org ) This software is distributed
@@ -13,24 +14,40 @@ import org.jcodec.codecs.h264.io.model.SliceType;
  */
 public class DumbRateControl implements RateControl {
     private static final int QP = 20;
+    private int bitsPerMb;
+    private int totalQpDelta;
+    private boolean justSwitched;
 
     @Override
-    public int getInitQp(SliceType sliceType) {
+    public int accept(int bits) {
+        if (bits >= bitsPerMb) {
+            totalQpDelta ++;
+            justSwitched = true;
+            return 1;
+        } else {
+            // Only decrease qp if we got too few bits (more then 12.5%)
+            if (totalQpDelta > 0 && !justSwitched && (bitsPerMb - bits > (bitsPerMb >> 3))) {
+                -- totalQpDelta;
+                justSwitched = true;
+                return -1;
+            } else {
+                justSwitched = false;
+            }
+            return 0;
+        }
+    }
+
+    @Override
+    public int startPicture(Size sz, int maxSize, SliceType sliceType) {
+        int totalMb = ((sz.getWidth() + 15) >> 4) * ((sz.getHeight() + 15) >> 4);
+        bitsPerMb = (8 * maxSize) / totalMb;
+        totalQpDelta = 0;
+        justSwitched = false;
         return QP + (sliceType == SliceType.P ? 6 : 0);
     }
 
     @Override
-    public int getQpDelta() {
+    public int initialQpDelta() {
         return 0;
-    }
-
-    @Override
-    public boolean accept(int bits) {
-        return true;
-    }
-
-    @Override
-    public void reset() {
-        // Do nothing, remember we are dumb
     }
 }

--- a/src/main/java/org/jcodec/codecs/h264/encode/H264FixedRateControl.java
+++ b/src/main/java/org/jcodec/codecs/h264/encode/H264FixedRateControl.java
@@ -1,6 +1,7 @@
 package org.jcodec.codecs.h264.encode;
 
 import org.jcodec.codecs.h264.io.model.SliceType;
+import org.jcodec.common.model.Size;
 import org.jcodec.common.tools.MathUtil;
 
 /**
@@ -24,14 +25,14 @@ public class H264FixedRateControl implements RateControl {
     }
 
     @Override
-    public int getInitQp(SliceType sliceType) {
+    public int startPicture(Size sz, int maxSize, SliceType sliceType) {
         return INIT_QP + (sliceType == SliceType.P ? 4 : 0);
     }
 
     @Override
-    public int getQpDelta() {
-        int qpDelta = balance < 0 ? (balance < -(perMb >> 1) ? 2 : 1) : (balance > perMb ? (balance > (perMb << 2) ? -2
-                : -1) : 0);
+    public int initialQpDelta() {
+        int qpDelta = balance < 0 ? (balance < -(perMb >> 1) ? 2 : 1)
+                : (balance > perMb ? (balance > (perMb << 2) ? -2 : -1) : 0);
         int prevQp = curQp;
         curQp = MathUtil.clip(curQp + qpDelta, 12, 30);
 
@@ -39,16 +40,13 @@ public class H264FixedRateControl implements RateControl {
     }
 
     @Override
-    public boolean accept(int bits) {
+    public int accept(int bits) {
 
         balance += perMb - bits;
 
-        // System.out.println(balance);
-
-        return true;
+        return 0;
     }
 
-    @Override
     public void reset() {
         balance = 0;
         curQp = INIT_QP;

--- a/src/main/java/org/jcodec/codecs/h264/encode/RateControl.java
+++ b/src/main/java/org/jcodec/codecs/h264/encode/RateControl.java
@@ -1,6 +1,7 @@
 package org.jcodec.codecs.h264.encode;
 
 import org.jcodec.codecs.h264.io.model.SliceType;
+import org.jcodec.common.model.Size;
 
 /**
  * This class is part of JCodec ( www.jcodec.org ) This software is distributed
@@ -13,12 +14,9 @@ import org.jcodec.codecs.h264.io.model.SliceType;
  */
 public interface RateControl {
 
-    int getInitQp(SliceType sliceType);
+    int startPicture(Size sz, int maxSize, SliceType sliceType);
 
-    int getQpDelta();
-
-    boolean accept(int bits);
-
-    void reset();
-
+    int initialQpDelta(); 
+    
+    int accept(int bits);
 }

--- a/src/test/java/org/jcodec/codecs/h264/H264EncoderTest.java
+++ b/src/test/java/org/jcodec/codecs/h264/H264EncoderTest.java
@@ -3,6 +3,7 @@ package org.jcodec.codecs.h264;
 import static org.junit.Assert.assertNotNull;
 
 import java.nio.ByteBuffer;
+import java.util.Random;
 
 import org.jcodec.codecs.h264.encode.H264FixedRateControl;
 import org.jcodec.codecs.h264.io.model.Frame;
@@ -104,5 +105,19 @@ public class H264EncoderTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testRandomImage() {
+        H264Encoder encoder = H264Encoder.createH264Encoder();
+        Picture pic = Picture.create(640, 360, ColorSpace.YUV420J);
+
+        for (int i = 0; i < 3; i++) {
+            byte[] planeData = pic.getPlaneData(i);
+            new Random().nextBytes(planeData);
+        }
+
+        ByteBuffer out = ByteBuffer.allocate((3 * 640 * 360) / 2);
+        encoder.encodeFrame(pic, out);
     }
 }

--- a/src/test/java/org/jcodec/codecs/h264/encode/H264FixedRateControlTest.java
+++ b/src/test/java/org/jcodec/codecs/h264/encode/H264FixedRateControlTest.java
@@ -1,0 +1,30 @@
+package org.jcodec.codecs.h264.encode;
+
+import org.jcodec.codecs.h264.io.model.SliceType;
+import org.jcodec.common.model.Size;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class H264FixedRateControlTest {
+
+    @Test
+    public void testRateControl() {
+        int[] initQp = { 26, 30, 26 };
+        int[][] qpDelta = { { 0, 1, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0 },
+                { 0, 2, 1, 0, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0 },
+                { 0, 0, 1, 1, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1 } };
+        int[][] bits = { { 1222, 1485, 1566, 810, 1110, 720, 1020, 660, 930, 870, 330, 510, 1102, 1073, 435 },
+                { 1710, 416, 132, 627, 384, 1116, 1620, 1102, 784, 1026, 1378, 1014, 1066, 988, 1092 },
+                { 910, 1144, 1053, 644, 504, 336, 837, 1326, 625, 744, 598, 1452, 525, 320, 969, } };
+        for (int i = 0; i < 3; i++) {
+            H264FixedRateControl rc = new H264FixedRateControl(1024);
+            rc.reset();
+            Assert.assertEquals(initQp[i],
+                    rc.startPicture(new Size(0, 0), 0, i == 0 ? SliceType.I : (i == 1 ? SliceType.P : SliceType.B)));
+            for (int j = 0; j < qpDelta[i].length; j++) {
+                Assert.assertEquals(qpDelta[i][j], rc.initialQpDelta());
+                Assert.assertEquals(0, rc.accept(bits[i][j]));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prevents explosion of bits on randomly generated videos by strictly limiting the number of bits per macroblock.