### PR TITLE
BitReader throw exception when input is exhausted.

### DIFF
--- a/src/main/java/org/jcodec/codecs/h264/io/model/PictureParameterSet.java
+++ b/src/main/java/org/jcodec/codecs/h264/io/model/PictureParameterSet.java
@@ -99,9 +99,13 @@ public class PictureParameterSet {
     public PictureParameterSet() {
         this.numRefIdxActiveMinus1 = new int[2];
     }
-    
+
     public static PictureParameterSet read(ByteBuffer is) {
         BitReader _in = BitReader.createBitReader(is);
+        return read(_in);
+    }
+
+    public static PictureParameterSet read(BitReader _in) {
         PictureParameterSet pps = new PictureParameterSet();
 
         pps.picParameterSetId = readUEtrace(_in, "PPS: pic_parameter_set_id");

--- a/src/main/java/org/jcodec/codecs/h264/io/model/SeqParameterSet.java
+++ b/src/main/java/org/jcodec/codecs/h264/io/model/SeqParameterSet.java
@@ -177,6 +177,10 @@ public class SeqParameterSet {
 
     public static SeqParameterSet read(ByteBuffer is) {
         BitReader _in = BitReader.createBitReader(is);
+        return read(_in);
+    }
+
+    public static SeqParameterSet read(BitReader _in) {
         SeqParameterSet sps = new SeqParameterSet();
 
         sps.profileIdc = readNBit(_in, 8, "SPS: profile_idc");

--- a/src/main/java/org/jcodec/codecs/h264/io/model/SeqParameterSetExt.java
+++ b/src/main/java/org/jcodec/codecs/h264/io/model/SeqParameterSetExt.java
@@ -32,7 +32,10 @@ public class SeqParameterSetExt {
 
     public static SeqParameterSetExt read(ByteBuffer is) {
         BitReader _in = BitReader.createBitReader(is);
+        return read(_in);
+    }
 
+    public static SeqParameterSetExt read(BitReader _in) {
         SeqParameterSetExt spse = new SeqParameterSetExt();
         spse.seq_parameter_set_id = readUEtrace(_in, "SPSE: seq_parameter_set_id");
         spse.aux_format_idc = readUEtrace(_in, "SPSE: aux_format_idc");


### PR DESCRIPTION
It happened that on some bad data we get in infinite loop inside the SliceHeaderReader#readReorderingEntries method.

I've made it possible to supply a BitReader that throws exception when input is exhausted. This way if an infinite loop happens the BitReader#readInt() will eventually throw IllegalStateException instead of returning 0 and looping forever.

I need extra safety also for H264 Sps and Pps that is why I added read methods that take BitReader as an argument.