### PR TITLE
Fix #410 slow metadata save not closing resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
 				<version>3.3</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>8</source>
+					<target>8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/jcodec/containers/mp4/ChunkWriter.java
+++ b/src/main/java/org/jcodec/containers/mp4/ChunkWriter.java
@@ -123,4 +123,10 @@ public class ChunkWriter {
             sampleCount += chunk.getSampleCount();
         }
     }
+
+    public void close() throws IOException {
+        for (SeekableByteChannel input : inputs) {
+            input.close();
+        }
+    }
 }

--- a/src/main/java/org/jcodec/movtool/Flatten.java
+++ b/src/main/java/org/jcodec/movtool/Flatten.java
@@ -155,6 +155,7 @@ public class Flatten {
 
         for (int i = 0; i < tracks.length; i++) {
             writers[i].apply();
+            writers[i].close();
         }
         long mdatSize = out.position() - mdatOff;
 

--- a/src/main/java/org/jcodec/movtool/ReplaceMP4Editor.java
+++ b/src/main/java/org/jcodec/movtool/ReplaceMP4Editor.java
@@ -32,6 +32,7 @@ public class ReplaceMP4Editor {
     public void replace(File src, MP4Edit edit) throws IOException {
         File tmp = new File(src.getParentFile(), "." + src.getName());
         copy(src, tmp, edit);
+        src.delete();
         tmp.renameTo(src);
     }
 


### PR DESCRIPTION
* Change Java Version to 8 because of org.jcodec.api.transcode.SinkImpl using java.lang.reflect.Parameter
* Close inputs at slow metadata save and delete and then move. This also fixes the test testKeyedWriteSlow() (on Windows)