### PR TITLE
Fixed issue when codecId contains nul character

### DIFF
--- a/src/main/java/org/jcodec/containers/mkv/demuxer/MKVDemuxer.java
+++ b/src/main/java/org/jcodec/containers/mkv/demuxer/MKVDemuxer.java
@@ -231,7 +231,7 @@ public final class MKVDemuxer implements Demuxer {
                 String language = "eng";
                 MKVType[] path10 = { TrackEntry, MKVType.CodecID };
                 EbmlString codecId = (EbmlString) findFirst(elemTrack, path10);
-                Codec codec = codecAudioMapping.get(codecId.getString());
+                Codec codec = codecAudioMapping.get(codecId.getString().replace("\0", ""));
                 if (codec == null) {
                     System.out.println("Unknown audio codec: '" + codecId.getString() + "'");
                 }


### PR DESCRIPTION
When I tried to decode using the file I have, I noticed that the jcodec library outputs the message `Unknown audio codec: 'A_OPUS'`. When I debugged it, I realized that the A_OPUS header was followed by a nul character. 

<img width="926" alt="SCR-20230302-lzq-3" src="https://user-images.githubusercontent.com/5145369/222353956-aee173dd-90e1-49fe-bfec-36001c8d6001.png">

After applying the above changes, I noticed that the warning message that was being output to sysout was no longer output.