### PR TITLE
Fix ReplaceMp4Editor on Windows

### DIFF
--- a/src/main/java/org/jcodec/movtool/ReplaceMP4Editor.java
+++ b/src/main/java/org/jcodec/movtool/ReplaceMP4Editor.java
@@ -28,6 +28,7 @@ public class ReplaceMP4Editor {
     public void replace(File src, MP4Edit edit) throws IOException {
         File tmp = new File(src.getParentFile(), "." + src.getName());
         copy(src, tmp, edit);
+        src.delete();
         tmp.renameTo(src);
     }
 


### PR DESCRIPTION
Could not build on Windows because MetadataEditorTest threw a NPE.
The reason is that on Windows, renameTo() fails if target file exists. ReplaceMp4Editor performs changes in a tmp file then calls renameTo() to replace the source with the edited version, but that call failed (causing the MetadataEditorTest to analyse the source file a second time).
This one-line fix deletes the source before calling renameTo().